### PR TITLE
test: stabilize frontend headless tests and add Angular checks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,15 @@ on:
     branches:
       - main
       - "feature/**"
+      - "chore/**"
       - "docs/**"
   pull_request:
     branches:
       - main
 
 jobs:
-  test:
-    name: Build and test
+  backend:
+    name: Backend tests
     runs-on: ubuntu-latest
 
     steps:
@@ -31,3 +32,31 @@ jobs:
 
       - name: Run test suite
         run: ./mvnw -B test
+
+  frontend:
+    name: Frontend build and tests
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Run frontend tests
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -121,8 +121,11 @@ npm run build
 Testes do frontend:
 
 ```bash
-CHROME_BIN=$(which google-chrome || which chromium || which chromium-browser) npm test -- --watch=false --browsers=ChromeHeadless
+npm test
 ```
+
+O script usa `ChromeHeadlessNoSandbox`, que se mostrou mais estavel para a
+validacao local e no CI.
 
 ### Fluxo local completo
 
@@ -154,6 +157,13 @@ Fluxo sugerido para primeira execucao:
 4. vincular suas principais skills ao perfil
 5. criar uma candidatura
 6. abrir o detalhe da candidatura e explorar etapas, notas, requisitos e matching
+
+Tambem da para usar o proprio dashboard como central operacional para:
+
+- registrar nota rapida
+- iniciar ou concluir a proxima etapa
+- limpar a proxima acao manual
+- encerrar ou reativar candidaturas sem abrir o detalhe
 
 ## Perfis de configuracao
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -12,7 +12,13 @@ sem depender apenas de requests manuais.
   - vincular skills ao perfil do usuario
   - criar candidaturas
 - lista de candidaturas com filtros por empresa e status
-- painel com leitura de prioridades baseada em etapas e prazos
+- painel com leitura de prioridades baseada em etapas, prazos e proximas acoes
+- fila de triagem com atalhos para candidaturas que pedem atencao agora
+- acoes rapidas no dashboard para:
+  - registrar nota rapida
+  - iniciar ou concluir etapa
+  - limpar proxima acao manual
+  - encerrar ou reativar candidatura
 - detalhe de candidatura com:
   - status macro
   - requisitos da vaga
@@ -20,7 +26,7 @@ sem depender apenas de requests manuais.
   - notas
   - historico consolidado
   - leitura de matching
-  - remocao de requisito, nota e etapa
+  - edicao e remocao de requisito, nota e etapa
 
 ## Requisitos
 
@@ -68,5 +74,8 @@ npm run build
 ## Testes
 
 ```bash
-CHROME_BIN=$(which google-chrome || which chromium || which chromium-browser) npm test -- --watch=false --browsers=ChromeHeadless
+npm test
 ```
+
+O script usa `ChromeHeadlessNoSandbox`, que ficou mais estavel para execucao
+local e no GitHub Actions.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "start:host": "ng serve --host 0.0.0.0 --proxy-config proxy.conf.json",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test --watch=false"
+    "test": "ng test --watch=false --browsers=ChromeHeadlessNoSandbox"
   },
   "private": true,
   "packageManager": "npm@10.9.2",


### PR DESCRIPTION
## Summary
This PR stabilizes the Angular test flow and expands CI so the frontend is validated automatically together with the backend.

## Changes
- updates the frontend test script to use `ChromeHeadlessNoSandbox`
- keeps Angular tests runnable in local environments where the default Chrome launcher was unstable
- expands GitHub Actions CI with a dedicated frontend job
- adds frontend validation steps in CI:
  - `npm ci`
  - `npm run build`
  - `npm test`
- keeps the backend test job in place
- updates README documentation to reflect:
  - the current frontend test command
  - the dashboard workflow now supported by the product
  - the local full-stack experience more accurately

## Why
The project had already become much more functional, but the frontend test flow was still fragile in practice and CI was only checking the backend. This PR closes that gap so contributors and recruiters can clone the project and get more reliable validation out of the box.

## Validation
- `npm test` in `frontend/`
- `npm run build` in `frontend/`

