### PR TITLE
chore: add one-command full-stack startup with Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,14 @@ Executar a aplicacao com Docker Compose:
 docker compose up --build
 ```
 
-Esse fluxo sobe o backend e o banco local. O frontend Angular continua sendo
-executado separadamente em `frontend/`.
+Esse fluxo sobe:
+
+- PostgreSQL
+- backend Spring Boot
+- frontend Angular em `http://localhost:4200`
+
+Na primeira execucao, o frontend pode demorar um pouco mais porque instala as
+dependencias dentro do container antes de subir o `ng serve`.
 
 Executar os testes:
 
@@ -129,7 +135,17 @@ validacao local e no CI.
 
 ### Fluxo local completo
 
-Em dois terminais:
+Opcao mais simples, com um comando so:
+
+```bash
+docker compose up --build
+```
+
+Depois abra:
+
+- `http://localhost:4200`
+
+Opcao alternativa, se quiser rodar sem Docker:
 
 Terminal 1:
 
@@ -144,10 +160,6 @@ cd frontend
 npm install
 npm start
 ```
-
-Depois abra:
-
-- `http://localhost:4200`
 
 Fluxo sugerido para primeira execucao:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,5 +37,19 @@ services:
       postgres:
         condition: service_healthy
 
+  frontend:
+    image: node:22-alpine
+    working_dir: /workspace
+    command: sh -c "npm install && npm run start:docker"
+    volumes:
+      - ./frontend:/workspace
+      - frontend-node-modules:/workspace/node_modules
+    ports:
+      - "4200:4200"
+    depends_on:
+      app:
+        condition: service_started
+
 volumes:
   postgres-data:
+  frontend-node-modules:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -36,6 +36,23 @@ sem depender apenas de requests manuais.
 
 ## Rodando localmente
 
+Opcao mais simples na raiz do projeto:
+
+```bash
+docker compose up --build
+```
+
+Depois abra:
+
+```text
+http://localhost:4200
+```
+
+Nesse modo, o frontend sobe no proprio compose e usa `proxy.docker.conf.json`
+para encaminhar `/api` e `/actuator` para o servico `app`.
+
+Se preferir rodar so o frontend fora do Docker:
+
 Instale as dependencias:
 
 ```bash

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.conf.json",
+    "start:docker": "ng serve --host 0.0.0.0 --proxy-config proxy.docker.conf.json",
     "start:host": "ng serve --host 0.0.0.0 --proxy-config proxy.conf.json",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",

--- a/frontend/proxy.docker.conf.json
+++ b/frontend/proxy.docker.conf.json
@@ -1,0 +1,12 @@
+{
+  "/api": {
+    "target": "http://app:8080",
+    "secure": false,
+    "changeOrigin": true
+  },
+  "/actuator": {
+    "target": "http://app:8080",
+    "secure": false,
+    "changeOrigin": true
+  }
+}


### PR DESCRIPTION
## Summary
This PR improves the local developer experience by allowing the full stack to be started with a single `docker compose up --build` command.

## Changes
- adds the Angular frontend as a service in `docker-compose.yml`
- adds a Docker-specific frontend proxy configuration pointing to the backend service
- adds a dedicated frontend start script for containerized execution
- updates root and frontend documentation to describe:
  - one-command full-stack startup
  - the new Docker-based local workflow
  - the alternative non-Docker workflow

## Why
The project had already become much more functional, but local full-stack startup still required extra manual steps. This PR reduces setup friction for day-to-day use and makes the repository more welcoming for technical reviewers who want to clone and run everything quickly.

## Validation
- `docker compose config`
- `docker compose up -d`
- `curl -I http://localhost:4200`
- `npm run build` in `frontend/`
## Summary
This PR improves the local developer experience by allowing the full stack to be started with a single `docker compose up --build` command.

## Changes
- adds the Angular frontend as a service in `docker-compose.yml`
- adds a Docker-specific frontend proxy configuration pointing to the backend service
- adds a dedicated frontend start script for containerized execution
- updates root and frontend documentation to describe:
  - one-command full-stack startup
  - the new Docker-based local workflow
  - the alternative non-Docker workflow

## Why
The project had already become much more functional, but local full-stack startup still required extra manual steps. This PR reduces setup friction for day-to-day use and makes the repository more welcoming for technical reviewers who want to clone and run everything quickly.

## Validation
- `docker compose config`
- `docker compose up -d`
- `curl -I http://localhost:4200`
- `npm run build` in `frontend/`
