### PR TITLE
feat: add a dynamic onboarding checklist to the dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,14 @@ Executar a aplicacao com Docker Compose:
 docker compose up --build
 ```
 
-Esse fluxo sobe o backend e o banco local. O frontend Angular continua sendo
-executado separadamente em `frontend/`.
+Esse fluxo sobe:
+
+- PostgreSQL
+- backend Spring Boot
+- frontend Angular em `http://localhost:4200`
+
+Na primeira execucao, o frontend pode demorar um pouco mais porque instala as
+dependencias dentro do container antes de subir o `ng serve`.
 
 Executar os testes:
 
@@ -129,7 +135,17 @@ validacao local e no CI.
 
 ### Fluxo local completo
 
-Em dois terminais:
+Opcao mais simples, com um comando so:
+
+```bash
+docker compose up --build
+```
+
+Depois abra:
+
+- `http://localhost:4200`
+
+Opcao alternativa, se quiser rodar sem Docker:
 
 Terminal 1:
 
@@ -144,10 +160,6 @@ cd frontend
 npm install
 npm start
 ```
-
-Depois abra:
-
-- `http://localhost:4200`
 
 Fluxo sugerido para primeira execucao:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,5 +37,19 @@ services:
       postgres:
         condition: service_healthy
 
+  frontend:
+    image: node:22-alpine
+    working_dir: /workspace
+    command: sh -c "npm install && npm run start:docker"
+    volumes:
+      - ./frontend:/workspace
+      - frontend-node-modules:/workspace/node_modules
+    ports:
+      - "4200:4200"
+    depends_on:
+      app:
+        condition: service_started
+
 volumes:
   postgres-data:
+  frontend-node-modules:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -36,6 +36,23 @@ sem depender apenas de requests manuais.
 
 ## Rodando localmente
 
+Opcao mais simples na raiz do projeto:
+
+```bash
+docker compose up --build
+```
+
+Depois abra:
+
+```text
+http://localhost:4200
+```
+
+Nesse modo, o frontend sobe no proprio compose e usa `proxy.docker.conf.json`
+para encaminhar `/api` e `/actuator` para o servico `app`.
+
+Se preferir rodar so o frontend fora do Docker:
+
 Instale as dependencias:
 
 ```bash

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.conf.json",
+    "start:docker": "ng serve --host 0.0.0.0 --proxy-config proxy.docker.conf.json",
     "start:host": "ng serve --host 0.0.0.0 --proxy-config proxy.conf.json",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",

--- a/frontend/proxy.docker.conf.json
+++ b/frontend/proxy.docker.conf.json
@@ -1,0 +1,12 @@
+{
+  "/api": {
+    "target": "http://app:8080",
+    "secure": false,
+    "changeOrigin": true
+  },
+  "/actuator": {
+    "target": "http://app:8080",
+    "secure": false,
+    "changeOrigin": true
+  }
+}

--- a/frontend/src/app/pages/dashboard-page.component.html
+++ b/frontend/src/app/pages/dashboard-page.component.html
@@ -380,30 +380,41 @@
     <article class="panel stack" style="grid-column: span 4">
       <div class="panel-head">
         <div>
-          <h2 class="panel-title">Fluxo sugerido</h2>
+          <h2 class="panel-title">Checklist do workspace</h2>
           <p class="panel-subtitle">
-            Um jeito simples de usar o sistema no dia a dia.
+            Use este bloco para ver o que ja esta pronto e qual passo ainda falta para o fluxo ficar redondo.
           </p>
         </div>
       </div>
 
+      <div class="list-item">
+        <div class="split">
+          <strong>{{ workspaceChecklistProgress().completed }} de {{ workspaceChecklistProgress().total }} passos concluidos</strong>
+          <span class="muted">{{ workspaceChecklistProgress().percentage }}%</span>
+        </div>
+        @if (workspaceChecklistProgress().nextPending; as nextPending) {
+          <p class="muted">
+            Próximo foco: <strong>{{ nextPending.title }}</strong>. {{ nextPending.summary }}
+          </p>
+        } @else {
+          <p class="muted">
+            Seu workspace ja tem a base essencial para acompanhar candidaturas no dia a dia.
+          </p>
+        }
+      </div>
+
       <div class="list">
-        <div class="list-item">
-          <strong>1. Mapeie a vaga</strong>
-          <p class="muted">Cadastre empresa, titulo, senioridade e link da oportunidade.</p>
-        </div>
-        <div class="list-item">
-          <strong>2. Abra a candidatura</strong>
-          <p class="muted">Crie a candidatura vinculada ao seu perfil para comecar o acompanhamento.</p>
-        </div>
-        <div class="list-item">
-          <strong>3. Registre o andamento</strong>
-          <p class="muted">No detalhe, voce pode atualizar status, etapas, prazos e feedbacks.</p>
-        </div>
-        <div class="list-item">
-          <strong>4. Consulte a aderencia</strong>
-          <p class="muted">A analise aparece quando seu perfil e a vaga ja tiverem skills e requisitos cadastrados.</p>
-        </div>
+        @for (step of workspaceChecklist(); track step.id) {
+          <div class="list-item">
+            <div class="split">
+              <strong>{{ step.title }}</strong>
+              <span [class]="step.done ? 'tag tag-success' : 'tag tag-warning'">
+                {{ step.done ? 'Concluido' : 'Pendente' }}
+              </span>
+            </div>
+            <p class="muted">{{ step.summary }}</p>
+          </div>
+        }
       </div>
     </article>
   </div>

--- a/frontend/src/app/pages/dashboard-page.component.ts
+++ b/frontend/src/app/pages/dashboard-page.component.ts
@@ -78,6 +78,19 @@ interface UserSkillCard extends UserSkillResponse {
   skillCategory: string | null;
 }
 
+interface WorkspaceChecklistStep {
+  id:
+    | 'account'
+    | 'skill-catalog'
+    | 'user-profile'
+    | 'jobs'
+    | 'applications'
+    | 'follow-up';
+  title: string;
+  summary: string;
+  done: boolean;
+}
+
 @Component({
   selector: 'app-dashboard-page',
   standalone: true,
@@ -289,6 +302,88 @@ export class DashboardPageComponent {
       pendingPlanning: activeApplications.filter(
         (item) => item.stageAttention.urgency === 'unscheduled',
       ).length,
+    };
+  });
+
+  protected readonly workspaceChecklist = computed<WorkspaceChecklistStep[]>(() => {
+    const jobs = this.jobs();
+    const skills = this.skills();
+    const userSkills = this.userSkills();
+    const applicationCards = this.applicationCards();
+    const followUpReadyCount = applicationCards.filter(
+      (application) =>
+        application.nextAction !== null ||
+        application.notesCount > 0 ||
+        application.stagesCount > 0,
+    ).length;
+
+    return [
+      {
+        id: 'account',
+        title: 'Perfil conectado',
+        summary: this.knownUserId()
+          ? `Sessao reconhecida como ${this.auth.displayName()}.`
+          : 'Entre com sua conta para vincular candidaturas e skills ao seu perfil.',
+        done: !!this.knownUserId(),
+      },
+      {
+        id: 'skill-catalog',
+        title: 'Catálogo de skills montado',
+        summary:
+          skills.length > 0
+            ? `${skills.length} skill(s) cadastradas para reutilizar no perfil e nas vagas.`
+            : 'Cadastre as tecnologias que voce quer rastrear no produto.',
+        done: skills.length > 0,
+      },
+      {
+        id: 'user-profile',
+        title: 'Perfil técnico preenchido',
+        summary:
+          userSkills.length > 0
+            ? `${userSkills.length} skill(s) vinculadas ao seu perfil tecnico.`
+            : 'Vincule suas skills com nivel e experiencia para destravar o matching.',
+        done: userSkills.length > 0,
+      },
+      {
+        id: 'jobs',
+        title: 'Vagas mapeadas',
+        summary:
+          jobs.length > 0
+            ? `${jobs.length} vaga(s) ja estao prontas para gerar candidaturas.`
+            : 'Mapeie a primeira oportunidade que voce quer acompanhar aqui.',
+        done: jobs.length > 0,
+      },
+      {
+        id: 'applications',
+        title: 'Candidaturas abertas',
+        summary:
+          applicationCards.length > 0
+            ? `${applicationCards.length} candidatura(s) registradas no seu workspace.`
+            : 'Abra pelo menos uma candidatura para comecar a acompanhar o fluxo real.',
+        done: applicationCards.length > 0,
+      },
+      {
+        id: 'follow-up',
+        title: 'Acompanhamento com contexto',
+        summary:
+          followUpReadyCount > 0
+            ? `${followUpReadyCount} candidatura(s) ja possuem nota, etapa ou proxima acao.`
+            : 'Registre nota, etapa ou proxima acao para transformar o painel em rotina diaria.',
+        done: followUpReadyCount > 0,
+      },
+    ];
+  });
+
+  protected readonly workspaceChecklistProgress = computed(() => {
+    const steps = this.workspaceChecklist();
+    const completed = steps.filter((step) => step.done).length;
+    const nextPending = steps.find((step) => !step.done) ?? null;
+
+    return {
+      completed,
+      total: steps.length,
+      percentage: Math.round((completed / steps.length) * 100),
+      nextPending,
     };
   });
 


### PR DESCRIPTION
## Summary
This PR improves the dashboard onboarding experience by replacing the static usage guide with a dynamic workspace checklist.

## Changes
- replaces the static "Fluxo sugerido" panel with a checklist driven by real workspace data
- shows progress across the main setup steps:
  - authenticated profile
  - skill catalog
  - user technical profile
  - mapped jobs
  - tracked applications
  - follow-up context
- highlights the next pending step so the dashboard can guide first-time setup and ongoing usage
- keeps the checklist aligned with the actual product flow instead of a fixed explanatory text

## Why
The frontend already had a lot of capability, but the onboarding experience still depended on the user interpreting a static block of instructions. This PR makes the dashboard more self-explanatory and helps both new users and technical reviewers understand what is missing to make the workspace truly useful.

## Validation
- `npm run build` in `frontend/`
- `npm test` in `frontend/`
